### PR TITLE
Fix configuration server fetch hanging in preset manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,7 +1787,7 @@ dependencies = [
 
 [[package]]
 name = "golem-gpu-imager"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [package]
 name = "golem-gpu-imager"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 build = "build.rs"
 

--- a/src/ui/configuration/handler.rs
+++ b/src/ui/configuration/handler.rs
@@ -273,7 +273,8 @@ pub fn handle_message(
             if let Some(content) = &state.server_config_content {
                 if let Ok(config) = toml::from_str::<toml::Value>(content) {
                     apply_server_configuration_to_state(state, &config);
-                    // Keep the server content for writing to disk later
+                    // Clear the server content to hide the preview UI
+                    state.server_config_content = None;
                     debug!("Applied server configuration to state");
                 }
             }

--- a/src/ui/preset_manager/handler.rs
+++ b/src/ui/preset_manager/handler.rs
@@ -353,13 +353,26 @@ fn handle_editor_message(
         PresetEditorMessage::Configuration(config_msg) => {
             if let Some(editor) = &mut state.editor {
                 // Delegate configuration changes to the configuration handler
-                let _ = crate::ui::configuration::handle_message(
+                let task = crate::ui::configuration::handle_message(
                     &mut editor.configuration,
                     &state.presets,
                     config_msg,
                 );
+                
+                // Map the result messages to the correct context
+                task.map(|msg| match msg {
+                    crate::ui::messages::Message::Configuration(config_msg) => {
+                        crate::ui::messages::Message::PresetManager(
+                            PresetManagerMessage::Editor(
+                                PresetEditorMessage::Configuration(config_msg)
+                            )
+                        )
+                    }
+                    other => other,
+                })
+            } else {
+                Task::none()
             }
-            Task::none()
         }
     }
 }

--- a/src/ui/preset_manager/handler.rs
+++ b/src/ui/preset_manager/handler.rs
@@ -358,16 +358,14 @@ fn handle_editor_message(
                     &state.presets,
                     config_msg,
                 );
-                
                 // Map the result messages to the correct context
                 task.map(|msg| match msg {
                     crate::ui::messages::Message::Configuration(config_msg) => {
-                        crate::ui::messages::Message::PresetManager(
-                            PresetManagerMessage::Editor(
-                                PresetEditorMessage::Configuration(config_msg)
-                            )
-                        )
+                        crate::ui::messages::Message::PresetManager(PresetManagerMessage::Editor(
+                            PresetEditorMessage::Configuration(config_msg),
+                        ))
                     }
+                    // Forward all other messages unchanged (Edit, Flash, etc.)
                     other => other,
                 })
             } else {


### PR DESCRIPTION
## Summary
Fix configuration server fetch hanging in the preset manager edit flow. The fetch was working in the flash workflow but hanging in the preset manager due to message routing issues.

## Root Cause
The configuration handler was returning `Message::Configuration` messages, but in the preset manager context these need to be wrapped as `Message::PresetManager` messages to be handled correctly by the application's message routing system.

## Changes
- **Fix message routing**: Add proper message mapping in preset manager handler to route configuration messages back to the correct context
- **Fix UI state**: Clear `server_config_content` after applying configuration to hide the preview UI  
- **Proper Task handling**: Return the actual async Task instead of discarding it

## Test Plan
- [x] Configuration server fetch works in flash workflow (regression test)
- [x] Configuration server fetch now works in preset manager edit flow
- [x] Server configuration preview is displayed after fetch
- [x] Server configuration preview is hidden after applying
- [x] Applied configuration values are preserved in preset
- [x] Build succeeds with no new warnings

## Technical Details
The fix involved two key changes:

1. **Message routing fix** in `src/ui/preset_manager/handler.rs`:
   ```rust
   // Map the result messages to the correct context
   task.map( < /dev/null | msg| match msg {
       crate::ui::messages::Message::Configuration(config_msg) => {
           crate::ui::messages::Message::PresetManager(
               PresetManagerMessage::Editor(
                   PresetEditorMessage::Configuration(config_msg)
               )
           )
       }
       other => other,
   })
   ```

2. **UI state fix** in `src/ui/configuration/handler.rs`:
   ```rust
   // Clear the server content to hide the preview UI
   state.server_config_content = None;
   ```

Fixes issue where configuration server fetch would hang indefinitely in preset manager context.