### PR TITLE
Add profile-susteen compilation flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ lto = false
 default = []
 enterprise = []
 debug = []
+profile-susteen = []
 
 [package.metadata.bundle]
 name = "Golem GPU Imager"

--- a/src/utils/repo.rs
+++ b/src/utils/repo.rs
@@ -129,10 +129,19 @@ impl ImageRepo {
             ));
         }
 
-        let metadata: RepoMetadata = response
+        let mut metadata: RepoMetadata = response
             .json()
             .await
             .map_err(|e| format!("Failed to parse metadata: {}", e))?;
+
+        // In profile-susteen mode, filter channels to only show "susteen"
+        #[cfg(feature = "profile-susteen")]
+        {
+            metadata.channels = metadata.channels
+                .into_iter()
+                .filter(|channel| channel.name == "susteen")
+                .collect();
+        }
 
         // Cache the metadata
         if let Ok(mut cached_metadata) = self.metadata.lock() {


### PR DESCRIPTION
## Summary
- Add `profile-susteen` compilation flag for specialized Golem GPU Imager build
- Implement virtual preset system that fetches configuration from remote server
- Filter OS image channels to show only "susteen" channel
- Create isolated build profile for streamlined deployment

## Key Features
- **Remote Configuration**: Fetches preset from `http://63.176.129.155/config.toml`
- **Virtual Presets**: No disk persistence, fresh config on each startup
- **Filtered Channels**: Only shows "susteen" OS image channel
- **Auto-Applied**: Preset automatically applied for new images

## Technical Changes
- Added `profile-susteen` feature flag to `Cargo.toml`
- Implemented remote TOML config fetching in `PresetManager`
- Fixed environment variable mapping (YA_PAYMENT_NETWORK_GROUP, YA_NET_TYPE, SUBNET, YAGNA_METRICS_URL)
- Added conditional compilation for preset management functions
- Filtered repository metadata to show only "susteen" channel

## Usage
```bash
# Build with profile-susteen
cargo build --features profile-susteen

# Normal build (unchanged)
cargo build
```

## Test plan
- [x] Compiles successfully with and without feature flag
- [x] Remote config fetching works correctly
- [x] Environment variables mapped properly from nested TOML structure
- [x] Metrics service URL now correctly extracted from `env.YAGNA_METRICS_URL`
- [x] Only "susteen" channel displayed in OS image selection
- [x] Virtual preset system prevents disk persistence